### PR TITLE
Add images command, add commands to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,9 @@ The following `docker` commands are currently supported in some form
 - `docker logs` ⇒ `wharfer logs`
 - `docker ps` ⇒ `wharfer ps`
 - `docker kill` ⇒ `wharfer kill`
+- `docker rm` ⇒ `wharfer rm`
+- `docker pull` ⇒ `wharfer pull`
+- `docker images` ⇒ `wharfer images`
 
 To see the supported flags run `wharfer COMMAND --help`
 

--- a/main.go
+++ b/main.go
@@ -28,6 +28,7 @@ var kill wrap.Kill
 var rm wrap.Rm
 var logs wrap.Logs
 var pull wrap.Pull
+var images wrap.Images
 
 func init() {
 	build.InitFlags()
@@ -37,6 +38,7 @@ func init() {
 	logs.InitFlags()
 	rm.InitFlags()
 	pull.InitFlags()
+	images.InitFlags()
 }
 
 var version = "no-release"
@@ -52,6 +54,7 @@ func main() {
 		fmt.Fprintln(os.Stderr, "\trm")
 		fmt.Fprintln(os.Stderr, "\tlogs")
 		fmt.Fprintln(os.Stderr, "\tpull")
+		fmt.Fprintln(os.Stderr, "\timages")
 		os.Exit(1)
 	}
 
@@ -71,6 +74,8 @@ func main() {
 		args = ps.ParseToArgs(os.Args[2:])
 	case "pull":
 		args = pull.ParseToArgs(os.Args[2:])
+	case "images":
+		args = images.ParseToArgs(os.Args[2:])
 	case "--version":
 		fmt.Fprintln(os.Stderr, os.Args[0], "version", version)
 		os.Exit(0)

--- a/wrap/images.go
+++ b/wrap/images.go
@@ -1,0 +1,24 @@
+package wrap
+
+import (
+	"flag"
+)
+
+type Images struct {
+	Cmd    *flag.FlagSet
+	Format string
+}
+
+func (images *Images) InitFlags() {
+	images.Cmd = flag.NewFlagSet("images", flag.ExitOnError)
+	images.Cmd.StringVar(&images.Format, "format", "", "Pretty-print images using a Go template")
+}
+
+func (images *Images) ParseToArgs(rawArgs []string) []string {
+	images.Cmd.Parse(rawArgs)
+	args := []string{"images"}
+	if images.Format != "" {
+		args = append(args, "--format", images.Format)
+	}
+	return args
+}


### PR DESCRIPTION
Supports `-format` option for `images` command to be usable in scripts or other programs.