### PR TITLE
Add basic docker network functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ The following `docker` commands are currently supported in some form
 - `docker rm` ⇒ `wharfer rm`
 - `docker pull` ⇒ `wharfer pull`
 - `docker images` ⇒ `wharfer images`
+- `docker network` ⇒ `wharfer network`
 
 To see the supported flags run `wharfer COMMAND --help`
 

--- a/main.go
+++ b/main.go
@@ -29,6 +29,8 @@ var rm wrap.Rm
 var logs wrap.Logs
 var pull wrap.Pull
 var images wrap.Images
+var networkCreate wrap.NetworkCreate
+var networkRemove wrap.NetworkRemove
 
 func init() {
 	build.InitFlags()
@@ -39,6 +41,8 @@ func init() {
 	rm.InitFlags()
 	pull.InitFlags()
 	images.InitFlags()
+	networkCreate.InitFlags()
+	networkRemove.InitFlags()
 }
 
 var version = "no-release"
@@ -76,6 +80,13 @@ func main() {
 		args = pull.ParseToArgs(os.Args[2:])
 	case "images":
 		args = images.ParseToArgs(os.Args[2:])
+	case "network":
+		switch os.Args[2] {
+		case "create":
+			args = networkCreate.ParseToArgs(os.Args[3:])
+		case "rm":
+			args = networkRemove.ParseToArgs(os.Args[3:])
+		}
 	case "--version":
 		fmt.Fprintln(os.Stderr, os.Args[0], "version", version)
 		os.Exit(0)

--- a/main.go
+++ b/main.go
@@ -95,6 +95,12 @@ func main() {
 				args = networkList.ParseToArgs(os.Args[3:])
 			case "rm":
 				args = networkRemove.ParseToArgs(os.Args[3:])
+			case "--help":
+				fmt.Fprintln(os.Stderr, "Commands:")
+				fmt.Fprintln(os.Stderr, "\tcreate")
+				fmt.Fprintln(os.Stderr, "\tls")
+				fmt.Fprintln(os.Stderr, "\trm")
+				os.Exit(1)
 			default:
 				fmt.Fprintln(os.Stderr, "Unknown subcommand", os.Args[2])
 				os.Exit(1)

--- a/main.go
+++ b/main.go
@@ -30,6 +30,7 @@ var logs wrap.Logs
 var pull wrap.Pull
 var images wrap.Images
 var networkCreate wrap.NetworkCreate
+var networkList wrap.NetworkList
 var networkRemove wrap.NetworkRemove
 
 func init() {
@@ -42,6 +43,7 @@ func init() {
 	pull.InitFlags()
 	images.InitFlags()
 	networkCreate.InitFlags()
+	networkList.InitFlags()
 	networkRemove.InitFlags()
 }
 
@@ -59,6 +61,7 @@ func main() {
 		fmt.Fprintln(os.Stderr, "\tlogs")
 		fmt.Fprintln(os.Stderr, "\tpull")
 		fmt.Fprintln(os.Stderr, "\timages")
+		fmt.Fprintln(os.Stderr, "\tnetwork")
 		os.Exit(1)
 	}
 
@@ -81,11 +84,21 @@ func main() {
 	case "images":
 		args = images.ParseToArgs(os.Args[2:])
 	case "network":
-		switch os.Args[2] {
-		case "create":
-			args = networkCreate.ParseToArgs(os.Args[3:])
-		case "rm":
-			args = networkRemove.ParseToArgs(os.Args[3:])
+		if len(os.Args) < 3 {
+			fmt.Fprintln(os.Stderr, "Missing subcommand")
+			os.Exit(1)
+		} else {
+			switch os.Args[2] {
+			case "create":
+				args = networkCreate.ParseToArgs(os.Args[3:])
+			case "ls":
+				args = networkList.ParseToArgs(os.Args[3:])
+			case "rm":
+				args = networkRemove.ParseToArgs(os.Args[3:])
+			default:
+				fmt.Fprintln(os.Stderr, "Unknown subcommand", os.Args[2])
+				os.Exit(1)
+			}
 		}
 	case "--version":
 		fmt.Fprintln(os.Stderr, os.Args[0], "version", version)

--- a/wrap/kill.go
+++ b/wrap/kill.go
@@ -19,7 +19,12 @@ func (kill *Kill) ParseToArgs(rawArgs []string) []string {
 		// add -- to make sure additional arguments are not interpreted as
 		// potentially harmful flags. Here this is the container to kill
 		args = append(args, "--")
-		args = append(args, kill.Cmd.Args()...)
+		for _, arg := range kill.Cmd.Args() {
+			if !IsHexOnly(arg) {
+				arg = PrependUsername(arg)
+			}
+			args = append(args, arg)
+		}
 	}
 	return args
 }

--- a/wrap/logs.go
+++ b/wrap/logs.go
@@ -32,7 +32,12 @@ func (logs *Logs) ParseToArgs(rawArgs []string) []string {
 		// add -- to make sure additional arguments are not interpreted as
 		// potentially harmful flags. Here this is the container to logs
 		args = append(args, "--")
-		args = append(args, logs.Cmd.Args()...)
+		for _, arg := range logs.Cmd.Args() {
+			if !IsHexOnly(arg) {
+				arg = PrependUsername(arg)
+			}
+			args = append(args, arg)
+		}
 	}
 	return args
 }

--- a/wrap/network_create.go
+++ b/wrap/network_create.go
@@ -1,0 +1,27 @@
+package wrap
+
+import (
+	"flag"
+)
+
+type NetworkCreate struct {
+	Cmd *flag.FlagSet
+}
+
+func (c *NetworkCreate) InitFlags() {
+	c.Cmd = flag.NewFlagSet("create", flag.ExitOnError)
+}
+
+func (c *NetworkCreate) ParseToArgs(rawArgs []string) []string {
+	c.Cmd.Parse(rawArgs)
+	args := []string{"network", "create"}
+	if c.Cmd.NArg() > 0 {
+		// add -- to make sure additional arguments are not interpreted as
+		// potentially harmful flags.
+		args = append(args, "--")
+		for _, arg := range c.Cmd.Args() {
+			args = append(args, PrependUsername(arg))
+		}
+	}
+	return args
+}

--- a/wrap/network_ls.go
+++ b/wrap/network_ls.go
@@ -1,0 +1,19 @@
+package wrap
+
+import (
+	"flag"
+)
+
+type NetworkList struct {
+	Cmd *flag.FlagSet
+}
+
+func (c *NetworkList) InitFlags() {
+	c.Cmd = flag.NewFlagSet("create", flag.ExitOnError)
+}
+
+func (c *NetworkList) ParseToArgs(rawArgs []string) []string {
+	c.Cmd.Parse(rawArgs)
+	args := []string{"network", "ls"}
+	return args
+}

--- a/wrap/network_rm.go
+++ b/wrap/network_rm.go
@@ -1,0 +1,30 @@
+package wrap
+
+import (
+	"flag"
+)
+
+type NetworkRemove struct {
+	Cmd *flag.FlagSet
+}
+
+func (c *NetworkRemove) InitFlags() {
+	c.Cmd = flag.NewFlagSet("rm", flag.ExitOnError)
+}
+
+func (c *NetworkRemove) ParseToArgs(rawArgs []string) []string {
+	c.Cmd.Parse(rawArgs)
+	args := []string{"network", "rm"}
+	if c.Cmd.NArg() > 0 {
+		// add -- to make sure additional arguments are not interpreted as
+		// potentially harmful flags.
+		args = append(args, "--")
+		for _, arg := range c.Cmd.Args() {
+			if !IsHexOnly(arg) {
+				arg = PrependUsername(arg)
+			}
+			args = append(args, arg)
+		}
+	}
+	return args
+}

--- a/wrap/rm.go
+++ b/wrap/rm.go
@@ -26,7 +26,12 @@ func (rm *Rm) ParseToArgs(rawArgs []string) []string {
 		// add -- to make sure additional arguments are not interpreted as
 		// potentially harmful flags. Here this is the container to rm
 		args = append(args, "--")
-		args = append(args, rm.Cmd.Args()...)
+		for _, arg := range kill.Cmd.Args() {
+			if !IsHexOnly(arg) {
+				arg = PrependUsername(arg)
+			}
+			args = append(args, arg)
+		}
 	}
 	return args
 }

--- a/wrap/rm.go
+++ b/wrap/rm.go
@@ -26,7 +26,7 @@ func (rm *Rm) ParseToArgs(rawArgs []string) []string {
 		// add -- to make sure additional arguments are not interpreted as
 		// potentially harmful flags. Here this is the container to rm
 		args = append(args, "--")
-		for _, arg := range kill.Cmd.Args() {
+		for _, arg := range rm.Cmd.Args() {
 			if !IsHexOnly(arg) {
 				arg = PrependUsername(arg)
 			}

--- a/wrap/run.go
+++ b/wrap/run.go
@@ -4,7 +4,6 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"os/user"
 	"regexp"
 	"strings"
 
@@ -44,16 +43,11 @@ func (run *Run) InitFlags() {
 func (run *Run) ParseToArgs(rawArgs []string) []string {
 	run.Cmd.Parse(rawArgs)
 	args := []string{"run"}
-	user, err := user.Current()
-	if err != nil {
-		fmt.Fprintln(os.Stderr, "Failed to retrieve username")
-		os.Exit(3)
-	}
 	name := namesgenerator.GetRandomName(0)
 	if run.Name != "" {
 		name = run.Name
 	}
-	args = append(args, "--name", user.Username+"_"+name)
+	args = append(args, "--name", PrependUsername(name))
 
 	if run.RestartPolicy != "" {
 		args = append(args, "--restart", run.RestartPolicy)

--- a/wrap/run.go
+++ b/wrap/run.go
@@ -22,6 +22,7 @@ type Run struct {
 	InteractiveTTY bool
 	Name           string
 	Network        string
+	NetworkAlias   StringSliceFlag
 	RestartPolicy  string
 }
 
@@ -38,6 +39,7 @@ func (run *Run) InitFlags() {
 	run.Cmd.BoolVar(&run.InteractiveTTY, "it", false, "Run container interactively")
 	run.Cmd.StringVar(&run.Name, "name", "", "Name of the running container instance")
 	run.Cmd.StringVar(&run.Network, "network", "", "Connect a container to a network")
+	run.Cmd.Var(&run.NetworkAlias, "network-alias", "Add network-scoped alias for the container")
 	run.Cmd.StringVar(&run.RestartPolicy, "restart", "", "Restart policy e.g. 'unless-stopped'")
 	run.Cmd.StringVar(&run.EntryPoint, "entrypoint", "", "Override the default ENTRYPOINT")
 }
@@ -58,6 +60,12 @@ func (run *Run) ParseToArgs(rawArgs []string) []string {
 
 	if run.Network != "" {
 		args = append(args, "--network", PrependUsername(run.Network))
+	}
+
+	if len(run.NetworkAlias) > 0 {
+		for _, alias := range run.NetworkAlias {
+			args = append(args, "--network-alias", alias)
+		}
 	}
 
 	if run.EntryPoint != "" {

--- a/wrap/run.go
+++ b/wrap/run.go
@@ -104,7 +104,7 @@ func (run *Run) ParseToArgs(rawArgs []string) []string {
 
 	if run.Cmd.NArg() > 0 {
 		// add -- to make sure additional arguments are not interpreted as
-		// potentially harmful flags. Here this is the container name
+		// potentially harmful flags. Here these are args for the entrypoint.
 		args = append(args, "--")
 		args = append(args, run.Cmd.Args()...)
 	}

--- a/wrap/run.go
+++ b/wrap/run.go
@@ -21,6 +21,7 @@ type Run struct {
 	Init           bool
 	InteractiveTTY bool
 	Name           string
+	Network        string
 	RestartPolicy  string
 }
 
@@ -36,6 +37,7 @@ func (run *Run) InitFlags() {
 	run.Cmd.BoolVar(&run.Detach, "d", false, "Detach container after starting it. Disables interactive mode")
 	run.Cmd.BoolVar(&run.InteractiveTTY, "it", false, "Run container interactively")
 	run.Cmd.StringVar(&run.Name, "name", "", "Name of the running container instance")
+	run.Cmd.StringVar(&run.Network, "network", "", "Connect a container to a network")
 	run.Cmd.StringVar(&run.RestartPolicy, "restart", "", "Restart policy e.g. 'unless-stopped'")
 	run.Cmd.StringVar(&run.EntryPoint, "entrypoint", "", "Override the default ENTRYPOINT")
 }
@@ -52,6 +54,10 @@ func (run *Run) ParseToArgs(rawArgs []string) []string {
 	if run.RestartPolicy != "" {
 		args = append(args, "--restart", run.RestartPolicy)
 		run.NoRemove = true
+	}
+
+	if run.Network != "" {
+		args = append(args, "--network", PrependUsername(run.Network))
 	}
 
 	if run.EntryPoint != "" {

--- a/wrap/wrap.go
+++ b/wrap/wrap.go
@@ -1,6 +1,10 @@
 package wrap
 
 import (
+	"encoding/hex"
+	"fmt"
+	"os"
+	"os/user"
 	"strings"
 )
 
@@ -18,4 +22,22 @@ func (s *StringSliceFlag) Set(value string) error {
 type WrappedCommand interface {
 	InitFlags()
 	ParseToArgs(rawArgs []string) []string
+}
+
+func PrependUsername(s string) string {
+	user, err := user.Current()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Failed to retrieve username")
+		os.Exit(3)
+	}
+
+	if !strings.HasPrefix(s, user.Username+"_") {
+		return user.Username + "_" + s
+	}
+	return s
+}
+
+func IsHexOnly(s string) bool {
+	_, err := hex.DecodeString(s)
+	return err == nil
 }


### PR DESCRIPTION
This pull requests adds basic `docker network` subcommands:
- `create`
  Create a new network, name is prefixed with username
- `ls`
  List currently existing networks
- `rm`
  Remove network, names are prefixed with username. :warning: Users can remove all networks using ids