### PR TITLE
Add wharfer exec, go.sum file and simplify README

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,19 +123,8 @@ This makes distinguishing containers easier in a multi user context.
 
 ### Supported commands
 
-The following `docker` commands are currently supported in some form
-
-- `docker run` ⇒ `wharfer run`
-- `docker build` ⇒ `wharfer build`
-- `docker logs` ⇒ `wharfer logs`
-- `docker ps` ⇒ `wharfer ps`
-- `docker kill` ⇒ `wharfer kill`
-- `docker rm` ⇒ `wharfer rm`
-- `docker pull` ⇒ `wharfer pull`
-- `docker images` ⇒ `wharfer images`
-- `docker network` ⇒ `wharfer network`
-
-To see the supported flags run `wharfer COMMAND --help`
+All `docker` commands supported by `wharfer` can be listed by executing
+`wharfer` without additional flags.
 
 A note on Volumes
 -----------------

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/docker/docker v1.13.1 h1:5VBhsO6ckUxB0A8CE5LlUJdXzik9cbEbBTQ/ggeml7M=
+github.com/docker/docker v1.13.1 h1:IkZjBSIc8hBjLpqeAbeE5mca5mNgeatLHBy3GO78BWo=
 github.com/docker/docker v1.13.1/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/docker/docker v1.13.1 h1:5VBhsO6ckUxB0A8CE5LlUJdXzik9cbEbBTQ/ggeml7M=
+github.com/docker/docker v1.13.1/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=

--- a/main.go
+++ b/main.go
@@ -21,34 +21,34 @@ func execDocker(args ...string) {
 	}
 }
 
-var build wrap.Build
-var run wrap.Run
-var ps wrap.Ps
-var kill wrap.Kill
-var rm wrap.Rm
-var logs wrap.Logs
-var pull wrap.Pull
-var images wrap.Images
-var networkCreate wrap.NetworkCreate
-var networkList wrap.NetworkList
-var networkRemove wrap.NetworkRemove
-var attach wrap.Attach
-var execcmd wrap.Exec
+var buildCmd wrap.Build
+var runCmd wrap.Run
+var psCmd wrap.Ps
+var killCmd wrap.Kill
+var rmCmd wrap.Rm
+var logsCmd wrap.Logs
+var pullCmd wrap.Pull
+var imagesCmd wrap.Images
+var networkCreateCmd wrap.NetworkCreate
+var networkListCmd wrap.NetworkList
+var networkRemoveCmd wrap.NetworkRemove
+var attachCmd wrap.Attach
+var execCmd wrap.Exec
 
 func init() {
-	build.InitFlags()
-	run.InitFlags()
-	ps.InitFlags()
-	kill.InitFlags()
-	logs.InitFlags()
-	rm.InitFlags()
-	pull.InitFlags()
-	images.InitFlags()
-	networkCreate.InitFlags()
-	networkList.InitFlags()
-	networkRemove.InitFlags()
-	attach.InitFlags()
-	execcmd.InitFlags()
+	buildCmd.InitFlags()
+	runCmd.InitFlags()
+	psCmd.InitFlags()
+	killCmd.InitFlags()
+	logsCmd.InitFlags()
+	rmCmd.InitFlags()
+	pullCmd.InitFlags()
+	imagesCmd.InitFlags()
+	networkCreateCmd.InitFlags()
+	networkListCmd.InitFlags()
+	networkRemoveCmd.InitFlags()
+	attachCmd.InitFlags()
+	execCmd.InitFlags()
 }
 
 var version = "no-release"
@@ -74,21 +74,21 @@ func main() {
 	var args []string
 	switch os.Args[1] {
 	case "build":
-		args = build.ParseToArgs(os.Args[2:])
+		args = buildCmd.ParseToArgs(os.Args[2:])
 	case "run":
-		args = run.ParseToArgs(os.Args[2:])
+		args = runCmd.ParseToArgs(os.Args[2:])
 	case "kill":
-		args = kill.ParseToArgs(os.Args[2:])
+		args = killCmd.ParseToArgs(os.Args[2:])
 	case "rm":
-		args = rm.ParseToArgs(os.Args[2:])
+		args = rmCmd.ParseToArgs(os.Args[2:])
 	case "logs":
-		args = logs.ParseToArgs(os.Args[2:])
+		args = logsCmd.ParseToArgs(os.Args[2:])
 	case "ps":
-		args = ps.ParseToArgs(os.Args[2:])
+		args = psCmd.ParseToArgs(os.Args[2:])
 	case "pull":
-		args = pull.ParseToArgs(os.Args[2:])
+		args = pullCmd.ParseToArgs(os.Args[2:])
 	case "images":
-		args = images.ParseToArgs(os.Args[2:])
+		args = imagesCmd.ParseToArgs(os.Args[2:])
 	case "network":
 		if len(os.Args) < 3 {
 			fmt.Fprintln(os.Stderr, "Missing subcommand")
@@ -96,11 +96,11 @@ func main() {
 		} else {
 			switch os.Args[2] {
 			case "create":
-				args = networkCreate.ParseToArgs(os.Args[3:])
+				args = networkCreateCmd.ParseToArgs(os.Args[3:])
 			case "ls":
-				args = networkList.ParseToArgs(os.Args[3:])
+				args = networkListCmd.ParseToArgs(os.Args[3:])
 			case "rm":
-				args = networkRemove.ParseToArgs(os.Args[3:])
+				args = networkRemoveCmd.ParseToArgs(os.Args[3:])
 			case "--help":
 				fmt.Fprintln(os.Stderr, "Commands:")
 				fmt.Fprintln(os.Stderr, "\tcreate")
@@ -113,9 +113,9 @@ func main() {
 			}
 		}
 	case "attach":
-		args = attach.ParseToArgs(os.Args[2:])
+		args = attachCmd.ParseToArgs(os.Args[2:])
 	case "exec":
-		args = execcmd.ParseToArgs(os.Args[2:])
+		args = execCmd.ParseToArgs(os.Args[2:])
 	case "--version":
 		fmt.Fprintln(os.Stderr, os.Args[0], "version", version)
 		os.Exit(0)

--- a/main.go
+++ b/main.go
@@ -33,6 +33,7 @@ var networkCreate wrap.NetworkCreate
 var networkList wrap.NetworkList
 var networkRemove wrap.NetworkRemove
 var attach wrap.Attach
+var execcmd wrap.Exec
 
 func init() {
 	build.InitFlags()
@@ -47,6 +48,7 @@ func init() {
 	networkList.InitFlags()
 	networkRemove.InitFlags()
 	attach.InitFlags()
+	execcmd.InitFlags()
 }
 
 var version = "no-release"
@@ -65,6 +67,7 @@ func main() {
 		fmt.Fprintln(os.Stderr, "\timages")
 		fmt.Fprintln(os.Stderr, "\tnetwork")
 		fmt.Fprintln(os.Stderr, "\tattach")
+		fmt.Fprintln(os.Stderr, "\texec")
 		os.Exit(1)
 	}
 
@@ -111,6 +114,8 @@ func main() {
 		}
 	case "attach":
 		args = attach.ParseToArgs(os.Args[2:])
+	case "exec":
+		args = execcmd.ParseToArgs(os.Args[2:])
 	case "--version":
 		fmt.Fprintln(os.Stderr, os.Args[0], "version", version)
 		os.Exit(0)

--- a/wrap/attach.go
+++ b/wrap/attach.go
@@ -2,31 +2,37 @@ package wrap
 
 import (
 	"flag"
+	"fmt"
+	"os"
 )
 
 type Attach struct {
 	Cmd *flag.FlagSet
 }
 
-func (c *Attach) InitFlags() {
-	c.Cmd = flag.NewFlagSet("attach", flag.ExitOnError)
+func (attach *Attach) InitFlags() {
+	attach.Cmd = flag.NewFlagSet("attach", flag.ExitOnError)
 }
 
-func (c *Attach) ParseToArgs(rawArgs []string) []string {
-	c.Cmd.Parse(rawArgs)
+func (attach *Attach) ParseToArgs(rawArgs []string) []string {
+	attach.Cmd.Parse(rawArgs)
 	args := []string{"attach"}
 
-	if c.Cmd.NArg() > 0 {
-		// add -- to make sure additional arguments are not interpreted as
-		// potentially harmful flags. Here this is the container to rm
-		args = append(args, "--")
-		for _, arg := range c.Cmd.Args() {
-			// If the container is given by name we prepend the user name
-			if !IsHexOnly(arg) {
-				arg = PrependUsername(arg)
-				args = append(args, arg)
-			}
-		}
+	if attach.Cmd.NArg() < 1 {
+		fmt.Fprintln(os.Stderr, "Missing [CONTAINER] argument")
+		os.Exit(3)
 	}
+
+	// add -- to make sure additional arguments are not interpreted as
+	// potentially harmful flags. Here these are args for the entrypoint.
+	args = append(args, "--")
+
+	// The [CONTAINER] positional argument
+	container := attach.Cmd.Args()[0]
+	// If the container is given by name we prepend the user name
+	if !IsHexOnly(container) {
+		container = PrependUsername(container)
+	}
+	args = append(args, container)
 	return args
 }

--- a/wrap/attach.go
+++ b/wrap/attach.go
@@ -21,7 +21,7 @@ func (c *Attach) ParseToArgs(rawArgs []string) []string {
 		// potentially harmful flags. Here this is the container to rm
 		args = append(args, "--")
 		for _, arg := range c.Cmd.Args() {
-			// Only allow attaching to named containers.
+			// If the container is given by name we prepend the user name
 			if !IsHexOnly(arg) {
 				arg = PrependUsername(arg)
 				args = append(args, arg)

--- a/wrap/exec.go
+++ b/wrap/exec.go
@@ -42,8 +42,7 @@ func (exec *Exec) ParseToArgs(rawArgs []string) []string {
 		}
 	}
 
-	argsLeft := exec.Cmd.NArg()
-	if argsLeft < 2 {
+	if exec.Cmd.NArg() < 2 {
 		fmt.Fprintln(os.Stderr, "Missing [CONTAINER] and/or [CMD] arguments")
 		os.Exit(3)
 	}
@@ -53,7 +52,7 @@ func (exec *Exec) ParseToArgs(rawArgs []string) []string {
 
 	// The [CONTAINER] positional argument
 	container := exec.Cmd.Args()[0]
-	argsLeft--
+	// If the container is given by name we prepend the user name
 	if !IsHexOnly(container) {
 		container = PrependUsername(container)
 	}
@@ -62,7 +61,6 @@ func (exec *Exec) ParseToArgs(rawArgs []string) []string {
 	// [COMMAND] argument
 	command := exec.Cmd.Args()[1]
 	args = append(args, command)
-	argsLeft--
 
 	// optional arguments
 	args = append(args, exec.Cmd.Args()[2:]...)

--- a/wrap/exec.go
+++ b/wrap/exec.go
@@ -1,0 +1,70 @@
+package wrap
+
+import (
+	"flag"
+	"fmt"
+	"os"
+)
+
+type Exec struct {
+	Cmd            *flag.FlagSet
+	Env            StringSliceFlag
+	Detach         bool
+	InteractiveTTY bool
+}
+
+func (exec *Exec) InitFlags() {
+	exec.Cmd = flag.NewFlagSet("exec", flag.ExitOnError)
+	exec.Cmd.Var(&exec.Env, "e", "Add an environment variable mapping of the form \"VARIABLE=value\"")
+	exec.Cmd.BoolVar(&exec.Detach, "d", false, "Detach container after starting it. Disables interactive mode")
+	exec.Cmd.BoolVar(&exec.InteractiveTTY, "it", false, "Run container interactively")
+}
+
+func (exec *Exec) ParseToArgs(rawArgs []string) []string {
+	exec.Cmd.Parse(rawArgs)
+	args := []string{"exec"}
+
+	// Always set --user $(id -u):$(id -g) so that when running without user
+	// namespaces we at least execute as the current user
+	args = appendCurrentUserArgs(args)
+
+	if exec.Detach {
+		args = append(args, "-d")
+	}
+
+	if exec.InteractiveTTY && !exec.Detach {
+		args = append(args, "-it")
+	}
+
+	if len(exec.Env) > 0 {
+		for _, execEnv := range exec.Env {
+			args = append(args, "-e", execEnv)
+		}
+	}
+
+	argsLeft := exec.Cmd.NArg()
+	if argsLeft < 2 {
+		fmt.Fprintln(os.Stderr, "Missing [CONTAINER] and/or [CMD] arguments")
+		os.Exit(3)
+	}
+	// add -- to make sure additional arguments are not interpreted as
+	// potentially harmful flags. Here these are args for the entrypoint.
+	args = append(args, "--")
+
+	// The [CONTAINER] positional argument
+	container := exec.Cmd.Args()[0]
+	argsLeft--
+	if !IsHexOnly(container) {
+		container = PrependUsername(container)
+	}
+	args = append(args, container)
+
+	// [COMMAND] argument
+	command := exec.Cmd.Args()[1]
+	args = append(args, command)
+	argsLeft--
+
+	// optional arguments
+	args = append(args, exec.Cmd.Args()[2:]...)
+	return args
+}


### PR DESCRIPTION
`wharfer exec` is added with support for environment variables and `-it` (as with `run` this differs from the separate `-i` and `-t` flags in `docker`). Detaching is also supported.