### PR TITLE
Fix lints found by GolangCI

### DIFF
--- a/wrap/attach.go
+++ b/wrap/attach.go
@@ -15,7 +15,10 @@ func (attach *Attach) InitFlags() {
 }
 
 func (attach *Attach) ParseToArgs(rawArgs []string) []string {
-	attach.Cmd.Parse(rawArgs)
+	if err := attach.Cmd.Parse(rawArgs); err != nil {
+		// Only returns an error if the Usage was shown
+		os.Exit(0)
+	}
 	args := []string{"attach"}
 
 	if attach.Cmd.NArg() < 1 {

--- a/wrap/build.go
+++ b/wrap/build.go
@@ -2,6 +2,7 @@ package wrap
 
 import (
 	"flag"
+	"os"
 )
 
 type Build struct {
@@ -27,7 +28,10 @@ func (build *Build) InitFlags() {
 }
 
 func (build *Build) ParseToArgs(rawArgs []string) []string {
-	build.Cmd.Parse(rawArgs)
+	if err := build.Cmd.Parse(rawArgs); err != nil {
+		// Only returns an error if the Usage was shown
+		os.Exit(0)
+	}
 	args := []string{"build"}
 	if build.File != "" {
 		args = append(args, "--file", build.File)

--- a/wrap/exec.go
+++ b/wrap/exec.go
@@ -21,7 +21,10 @@ func (exec *Exec) InitFlags() {
 }
 
 func (exec *Exec) ParseToArgs(rawArgs []string) []string {
-	exec.Cmd.Parse(rawArgs)
+	if err := exec.Cmd.Parse(rawArgs); err != nil {
+		// Only returns an error if the Usage was shown
+		os.Exit(0)
+	}
 	args := []string{"exec"}
 
 	// Always set --user $(id -u):$(id -g) so that when running without user

--- a/wrap/images.go
+++ b/wrap/images.go
@@ -2,6 +2,7 @@ package wrap
 
 import (
 	"flag"
+	"os"
 )
 
 type Images struct {
@@ -15,7 +16,10 @@ func (images *Images) InitFlags() {
 }
 
 func (images *Images) ParseToArgs(rawArgs []string) []string {
-	images.Cmd.Parse(rawArgs)
+	if err := images.Cmd.Parse(rawArgs); err != nil {
+		// Only returns an error if the Usage was shown
+		os.Exit(0)
+	}
 	args := []string{"images"}
 	if images.Format != "" {
 		args = append(args, "--format", images.Format)

--- a/wrap/kill.go
+++ b/wrap/kill.go
@@ -2,6 +2,7 @@ package wrap
 
 import (
 	"flag"
+	"os"
 )
 
 type Kill struct {
@@ -13,7 +14,10 @@ func (kill *Kill) InitFlags() {
 }
 
 func (kill *Kill) ParseToArgs(rawArgs []string) []string {
-	kill.Cmd.Parse(rawArgs)
+	if err := kill.Cmd.Parse(rawArgs); err != nil {
+		// Only returns an error if the Usage was shown
+		os.Exit(0)
+	}
 	args := []string{"kill"}
 	if kill.Cmd.NArg() > 0 {
 		// add -- to make sure additional arguments are not interpreted as

--- a/wrap/logs.go
+++ b/wrap/logs.go
@@ -2,6 +2,7 @@ package wrap
 
 import (
 	"flag"
+	"os"
 	"strconv"
 )
 
@@ -18,7 +19,10 @@ func (logs *Logs) InitFlags() {
 }
 
 func (logs *Logs) ParseToArgs(rawArgs []string) []string {
-	logs.Cmd.Parse(rawArgs)
+	if err := logs.Cmd.Parse(rawArgs); err != nil {
+		// Only returns an error if the Usage was shown
+		os.Exit(0)
+	}
 	args := []string{"logs"}
 	if logs.Follow {
 		args = append(args, "-f")

--- a/wrap/network_create.go
+++ b/wrap/network_create.go
@@ -2,6 +2,7 @@ package wrap
 
 import (
 	"flag"
+	"os"
 )
 
 type NetworkCreate struct {
@@ -13,7 +14,10 @@ func (c *NetworkCreate) InitFlags() {
 }
 
 func (c *NetworkCreate) ParseToArgs(rawArgs []string) []string {
-	c.Cmd.Parse(rawArgs)
+	if err := c.Cmd.Parse(rawArgs); err != nil {
+		// Only returns an error if the Usage was shown
+		os.Exit(0)
+	}
 	args := []string{"network", "create"}
 	if c.Cmd.NArg() > 0 {
 		// add -- to make sure additional arguments are not interpreted as

--- a/wrap/network_ls.go
+++ b/wrap/network_ls.go
@@ -2,6 +2,7 @@ package wrap
 
 import (
 	"flag"
+	"os"
 )
 
 type NetworkList struct {
@@ -13,7 +14,10 @@ func (c *NetworkList) InitFlags() {
 }
 
 func (c *NetworkList) ParseToArgs(rawArgs []string) []string {
-	c.Cmd.Parse(rawArgs)
+	if err := c.Cmd.Parse(rawArgs); err != nil {
+		// Only returns an error if the Usage was shown
+		os.Exit(0)
+	}
 	args := []string{"network", "ls"}
 	return args
 }

--- a/wrap/network_rm.go
+++ b/wrap/network_rm.go
@@ -2,6 +2,7 @@ package wrap
 
 import (
 	"flag"
+	"os"
 )
 
 type NetworkRemove struct {
@@ -13,7 +14,10 @@ func (c *NetworkRemove) InitFlags() {
 }
 
 func (c *NetworkRemove) ParseToArgs(rawArgs []string) []string {
-	c.Cmd.Parse(rawArgs)
+	if err := c.Cmd.Parse(rawArgs); err != nil {
+		// Only returns an error if the Usage was shown
+		os.Exit(0)
+	}
 	args := []string{"network", "rm"}
 	if c.Cmd.NArg() > 0 {
 		// add -- to make sure additional arguments are not interpreted as

--- a/wrap/ps.go
+++ b/wrap/ps.go
@@ -2,6 +2,7 @@ package wrap
 
 import (
 	"flag"
+	"os"
 )
 
 type Ps struct {
@@ -23,7 +24,10 @@ func (ps *Ps) InitFlags() {
 }
 
 func (ps *Ps) ParseToArgs(rawArgs []string) []string {
-	ps.Cmd.Parse(rawArgs)
+	if err := ps.Cmd.Parse(rawArgs); err != nil {
+		// Only returns an error if the Usage was shown
+		os.Exit(0)
+	}
 	args := []string{"ps"}
 	if ps.All {
 		args = append(args, "-a")

--- a/wrap/pull.go
+++ b/wrap/pull.go
@@ -2,6 +2,7 @@ package wrap
 
 import (
 	"flag"
+	"os"
 )
 
 type Pull struct {
@@ -13,7 +14,10 @@ func (pull *Pull) InitFlags() {
 }
 
 func (pull *Pull) ParseToArgs(rawArgs []string) []string {
-	pull.Cmd.Parse(rawArgs)
+	if err := pull.Cmd.Parse(rawArgs); err != nil {
+		// Only returns an error if the Usage was shown
+		os.Exit(0)
+	}
 	args := []string{"pull"}
 
 	if pull.Cmd.NArg() > 0 {

--- a/wrap/rm.go
+++ b/wrap/rm.go
@@ -2,6 +2,7 @@ package wrap
 
 import (
 	"flag"
+	"os"
 )
 
 type Rm struct {
@@ -15,7 +16,10 @@ func (rm *Rm) InitFlags() {
 }
 
 func (rm *Rm) ParseToArgs(rawArgs []string) []string {
-	rm.Cmd.Parse(rawArgs)
+	if err := rm.Cmd.Parse(rawArgs); err != nil {
+		// Only returns an error if the Usage was shown
+		os.Exit(0)
+	}
 	args := []string{"rm"}
 
 	if rm.Force {

--- a/wrap/run.go
+++ b/wrap/run.go
@@ -57,7 +57,7 @@ func isUserNamespaced() bool {
 		fmt.Fprintln(os.Stderr, "Failed to execute 'docker info'")
 		os.Exit(4)
 	}
-	return bytes.Index(output.Bytes(), []byte("userns")) != -1
+	return bytes.Contains(output.Bytes(), []byte("userns"))
 }
 
 // Appends the equivalent of -u $(id -u):$(id -g) to args if user namespacing is

--- a/wrap/run.go
+++ b/wrap/run.go
@@ -82,7 +82,10 @@ func appendCurrentUserArgs(args []string) []string {
 }
 
 func (run *Run) ParseToArgs(rawArgs []string) []string {
-	run.Cmd.Parse(rawArgs)
+	if err := run.Cmd.Parse(rawArgs); err != nil {
+		// Only returns an error if the Usage was shown
+		os.Exit(0)
+	}
 	args := []string{"run"}
 	name := namesgenerator.GetRandomName(0)
 	if run.Name != "" {


### PR DESCRIPTION
nothing major. The unhandled error for Parse resulted in an exit anyway because we set `ExitOnError` but it's definitely cleaner to make this explicit.