### PR TITLE
Add filter/format to network ls

### DIFF
--- a/wrap/network_create.go
+++ b/wrap/network_create.go
@@ -10,7 +10,7 @@ type NetworkCreate struct {
 }
 
 func (c *NetworkCreate) InitFlags() {
-	c.Cmd = flag.NewFlagSet("create", flag.ExitOnError)
+	c.Cmd = flag.NewFlagSet("network create", flag.ExitOnError)
 }
 
 func (c *NetworkCreate) ParseToArgs(rawArgs []string) []string {

--- a/wrap/network_ls.go
+++ b/wrap/network_ls.go
@@ -6,11 +6,19 @@ import (
 )
 
 type NetworkList struct {
-	Cmd *flag.FlagSet
+	Cmd    *flag.FlagSet
+	Format string
+	Filter string
+	Quiet  bool
 }
 
 func (c *NetworkList) InitFlags() {
-	c.Cmd = flag.NewFlagSet("create", flag.ExitOnError)
+	const filterUsage = "Filter output based on conditions provided"
+	c.Cmd = flag.NewFlagSet("network ls", flag.ExitOnError)
+	c.Cmd.StringVar(&c.Filter, "filter", "", filterUsage)
+	c.Cmd.StringVar(&c.Filter, "f", "", filterUsage+" (shorthand)")
+	c.Cmd.StringVar(&c.Format, "format", "", "Pretty-print images using a Go template")
+	c.Cmd.BoolVar(&c.Quiet, "q", false, "Only display numeric IDs")
 }
 
 func (c *NetworkList) ParseToArgs(rawArgs []string) []string {
@@ -19,5 +27,14 @@ func (c *NetworkList) ParseToArgs(rawArgs []string) []string {
 		os.Exit(0)
 	}
 	args := []string{"network", "ls"}
+	if c.Filter != "" {
+		args = append(args, "--filter", c.Filter)
+	}
+	if c.Format != "" {
+		args = append(args, "--format", c.Format)
+	}
+	if c.Quiet {
+		args = append(args, "-q")
+	}
 	return args
 }

--- a/wrap/network_rm.go
+++ b/wrap/network_rm.go
@@ -10,7 +10,7 @@ type NetworkRemove struct {
 }
 
 func (c *NetworkRemove) InitFlags() {
-	c.Cmd = flag.NewFlagSet("rm", flag.ExitOnError)
+	c.Cmd = flag.NewFlagSet("network rm", flag.ExitOnError)
 }
 
 func (c *NetworkRemove) ParseToArgs(rawArgs []string) []string {


### PR DESCRIPTION
This allows to filter the list of networks like:

```
$ wharfer network ls --format {{.ID}}:{{.Name}} --filter name=example
50222cec9a57:example
```

This is required to work on ad-freiburg/gantry#36