### PR TITLE
Add `wharfer rmi`

### DIFF
--- a/main.go
+++ b/main.go
@@ -26,6 +26,7 @@ var runCmd wrap.Run
 var psCmd wrap.Ps
 var killCmd wrap.Kill
 var rmCmd wrap.Rm
+var rmiCmd wrap.Rmi
 var loadCmd wrap.Load
 var saveCmd wrap.Save
 var logsCmd wrap.Logs
@@ -46,6 +47,7 @@ func init() {
 	saveCmd.InitFlags()
 	logsCmd.InitFlags()
 	rmCmd.InitFlags()
+	rmiCmd.InitFlags()
 	pullCmd.InitFlags()
 	imagesCmd.InitFlags()
 	networkCreateCmd.InitFlags()
@@ -61,19 +63,20 @@ func main() {
 	if len(os.Args) < 2 {
 		fmt.Fprintln(os.Stderr, "Usage:", os.Args[0], "<COMMAND>|--version")
 		fmt.Fprintln(os.Stderr, "Commands:")
-		fmt.Fprintln(os.Stderr, "\tbuild")
-		fmt.Fprintln(os.Stderr, "\trun")
-		fmt.Fprintln(os.Stderr, "\tps")
-		fmt.Fprintln(os.Stderr, "\tkill")
-		fmt.Fprintln(os.Stderr, "\trm")
-		fmt.Fprintln(os.Stderr, "\tload")
-		fmt.Fprintln(os.Stderr, "\tsave")
-		fmt.Fprintln(os.Stderr, "\tlogs")
-		fmt.Fprintln(os.Stderr, "\tpull")
-		fmt.Fprintln(os.Stderr, "\timages")
-		fmt.Fprintln(os.Stderr, "\tnetwork")
 		fmt.Fprintln(os.Stderr, "\tattach")
+		fmt.Fprintln(os.Stderr, "\tbuild")
 		fmt.Fprintln(os.Stderr, "\texec")
+		fmt.Fprintln(os.Stderr, "\timages")
+		fmt.Fprintln(os.Stderr, "\tkill")
+		fmt.Fprintln(os.Stderr, "\tload")
+		fmt.Fprintln(os.Stderr, "\tlogs")
+		fmt.Fprintln(os.Stderr, "\tnetwork")
+		fmt.Fprintln(os.Stderr, "\tps")
+		fmt.Fprintln(os.Stderr, "\tpull")
+		fmt.Fprintln(os.Stderr, "\trm")
+		fmt.Fprintln(os.Stderr, "\trmi")
+		fmt.Fprintln(os.Stderr, "\trun")
+		fmt.Fprintln(os.Stderr, "\tsave")
 		os.Exit(1)
 	}
 
@@ -87,6 +90,8 @@ func main() {
 		args = killCmd.ParseToArgs(os.Args[2:])
 	case "rm":
 		args = rmCmd.ParseToArgs(os.Args[2:])
+	case "rmi":
+		args = rmiCmd.ParseToArgs(os.Args[2:])
 	case "save":
 		args = saveCmd.ParseToArgs(os.Args[2:])
 	case "load":

--- a/wrap/rmi.go
+++ b/wrap/rmi.go
@@ -1,0 +1,41 @@
+package wrap
+
+import (
+	"flag"
+	"os"
+)
+
+type Rmi struct {
+	Cmd   *flag.FlagSet
+	Force bool
+}
+
+func (rmi *Rmi) InitFlags() {
+	rmi.Cmd = flag.NewFlagSet("rmi", flag.ExitOnError)
+	rmi.Cmd.BoolVar(&rmi.Force, "f", false, "Force removal of the image")
+}
+
+func (rmi *Rmi) ParseToArgs(rawArgs []string) []string {
+	if err := rmi.Cmd.Parse(rawArgs); err != nil {
+		// Only returns an error if the Usage was shown
+		os.Exit(0)
+	}
+	args := []string{"rmi"}
+
+	if rmi.Force {
+		args = append(args, "-f")
+	}
+
+	if rmi.Cmd.NArg() > 0 {
+		// add -- to make sure additional arguments are not interpreted as
+		// potentially harmful flags. Here this is the image to rm
+		args = append(args, "--")
+		for _, arg := range rmi.Cmd.Args() {
+			if !IsHexOnly(arg) {
+				arg = PrependUsername(arg)
+			}
+			args = append(args, arg)
+		}
+	}
+	return args
+}


### PR DESCRIPTION
This PR adds the highly requested `rmi` feature.

`rmi` is a copy of `rm` - logic for handling permissions is the same.

Also, this PR resorts the commands alphabetically as this is how docker does it.